### PR TITLE
Make atom shift focus back to text editor

### DIFF
--- a/lib/synced-sidebar.coffee
+++ b/lib/synced-sidebar.coffee
@@ -13,10 +13,10 @@ module.exports = SyncedSidebar =
     # Register command that toggles this view
     @subscriptions.add atom.workspace.onDidChangeActivePaneItem => @revealActiveFile()
 
-    atom.commands.add 'atom-workspace', 'pane:show-previous-item': ->
+    atom.commands.add 'body', 'pane:show-previous-item': ->
       atom.views.getView(atom.workspace).focus()
 
-    atom.commands.add 'atom-workspace', 'pane:show-next-item': ->
+    atom.commands.add 'body', 'pane:show-next-item': ->
       atom.views.getView(atom.workspace).focus()
 
   deactivate: ->


### PR DESCRIPTION
@peterdotjs , this was a really simple change, but it appears to do the trick, fixing #9. Just changed `atom.commands.add 'atom-workspace'` to `atom.commands.add 'body'` since atom is using "body" for its `pane:show-previous-item`/`pane:show-next-item` key maps now
