### PR TITLE
editor focus with MRU tab switching

### DIFF
--- a/lib/synced-sidebar.coffee
+++ b/lib/synced-sidebar.coffee
@@ -19,6 +19,12 @@ module.exports = SyncedSidebar =
     atom.commands.add 'body', 'pane:show-next-item': ->
       atom.views.getView(atom.workspace).focus()
 
+    atom.commands.add 'body', 'pane:show-previous-recently-used-item': ->
+      atom.views.getView(atom.workspace).focus()
+
+    atom.commands.add 'body', 'pane:show-next-recently-used-item': ->
+      atom.views.getView(atom.workspace).focus()
+
   deactivate: ->
     @subscriptions.dispose()
     @subscriptions = null


### PR DESCRIPTION
Hello,

This PR gives back the focus to the editor when switching tabs using MRU which is enabled by default since atom [1.7.0](https://github.com/atom/atom/releases/tag/v1.7.0).